### PR TITLE
CF workflow - GCP SA key rotations

### DIFF
--- a/workflow-templates/cf-gcp-key-rotation.properties.json
+++ b/workflow-templates/cf-gcp-key-rotation.properties.json
@@ -1,0 +1,5 @@
+{
+    "name": "Metro Digital: Cloud Foundation GCP key rotations",
+    "description": "Rotates Google Cloud Platform Service Account keys",
+    "iconName": "METRONOM-logo"
+}

--- a/workflow-templates/cf-gcp-key-rotation.yml
+++ b/workflow-templates/cf-gcp-key-rotation.yml
@@ -1,0 +1,124 @@
+#
+# Cloud Foundation 
+# Google Cloud Platform service account key rotation
+# 
+# This workflow rotates your service account key: 
+# * Creation of a new key for the service account
+# * Update of the GitHub secret
+# * Deletion of the old key in GCP
+#
+# Important: Do not use the same key file anywhere else!
+#
+# If you plan to use the same GCP SA within several Pipelines or similar you
+# shoud create one key per use case. Also ensure there is enough free headroom to
+# create additional keys as a service account can have up to 10 keys at the same time.
+# If you have more than one repository running key rotation for the same service account
+# keep in mind to adjust the default schedule to ensure that all keys are roated at
+# a different time or do not use more than 4-5 keys at all.
+#
+# Setup:
+#   * Create a service account that is able to rotate its own key
+#     * Preferable: Treat the service account as a resource and grant
+#       roles/iam.serviceAccountKeyAdmin on it to itself
+#
+#     * Alternative: Grant roles/iam.serviceAccountKeyAdmin on project
+#       level to the service account
+#       Warning: This allows the service account to change every other
+#       service account, too. Therefore this should be avoided!
+#
+#   * Create a service account key
+#     * Encode the keyfile using base64 (disable line wrapping)
+#     * Store it as a GitHub repository secret
+#
+#   * Create a personal access token with full repository access and store it within the
+#     secret PERSONAL_ACCESS_TOKEN
+#
+# The workflow assumes you are having multiple environments with different service accounts.
+# Each stage has a dedicated secret holding your sevice account key:
+#
+#     Env  | Secret name
+#     -----+---------------------------
+#     dev  | TERRAFORM_CREDENTIALS_DEV
+#     pp   | TERRAFORM_CREDENTIALS_PP
+#     prod | TERRAFORM_CREDENTIALS_PROD
+#
+# Amount of stages, names and secret names can be adjusted by modifing the jobs strategy matrix.
+
+name: 'GCP Key Rotation'
+
+on:
+  workflow_dispatch:            # run if triggered manual
+  schedule:                     
+    - cron: "0 10 * * 3"        # run every Wednesday at 10:00
+  push:                         # run if workflow itself is changed
+    branches: [ master ]
+    paths:
+      - '.github/workflows/cf-gcp-key-rotation.yml'   # change this if you changed the workflow file name
+
+jobs:
+  rotate:
+    name: Rotate gcp key
+    runs-on: ubuntu-latest
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      max-parallel: 1
+      matrix:
+        environment: [dev, pp, prod]
+        include:
+          - environment: dev
+            secret_name: TERRAFORM_CREDENTIALS_DEV
+          - environment: pp
+            secret_name: TERRAFORM_CREDENTIALS_PP
+          - environment: prod
+            secret_name: TERRAFORM_CREDENTIALS_PROD
+
+    steps:
+      - name: Extract details from current service account key
+        id: old-key
+        uses: metro-digital/cf-github-actions/gcp-read-sa-key@v1
+        with:
+          service_account_key: ${{ secrets[matrix.secret_name] }}
+
+      - name: Setup GCP CLI
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets[matrix.secret_name] }}
+          export_default_credentials: true
+        
+      - name: Generate new SA key
+        id: new-key
+        uses: metro-digital/cf-github-actions/gcp-create-sa-key@v1
+        with:
+          service_account_email: ${{ steps.old-key.outputs.client_email }}
+        
+      - name: Re-Setup GCP CLI (with new key)
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ steps.new-key.outputs.key_file }}
+          export_default_credentials: true
+
+      - name: "Update GitHub Secret"
+        uses: metro-digital/cf-github-actions/gh-update-secret@v1
+        with:
+          name: ${{ matrix.secret_name }}
+          value: ${{ steps.new-key.outputs.key_file }}
+          pa_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: Delete old key in case of success
+        if: ${{ success() }}
+        uses: metro-digital/cf-github-actions/gcp-delete-sa-key@v1
+        with:
+          service_account_email: ${{ steps.old-key.outputs.client_email }}
+          key_id: ${{ steps.old-key.outputs.private_key_id }}
+      
+      - name: Delete new key in case of failure
+        if: ${{ failure() && steps.new-key.outcome == 'success' }}
+        uses: metro-digital/cf-github-actions/gcp-delete-sa-key@v1
+        with:
+          service_account_email: ${{ steps.new-key.outputs.client_email }}
+          key_id: ${{ steps.new-key.outputs.private_key_id }}


### PR DESCRIPTION
As Cloud Foundation we ask our users to maintain the Cloud Infrastructure via IaC pipelines. Therefor we recommend terraform. To run terraform inside a GitHub Action you need to create a service account and auth to it. To auth you need a service account key and you store this key in GitHub secrets.

For security reasons we create Incidents if users do not rotate service account keys at least every 90 days.

This means Cloud Foundation needs to provide an easy way how to rotate the key endusers.
This workflow implements such a key rotation based on GitHub actions Cloud Foundation maintains.