### PR TITLE
Clarify use of working-directory setting

### DIFF
--- a/workflow-templates/cf-gcp-terraform.yml
+++ b/workflow-templates/cf-gcp-terraform.yml
@@ -49,6 +49,8 @@ jobs:
     defaults:
       run:
         shell: bash
+        # The working-directory is only needed if you have your terraform code in different folders per environment.
+        # Comment or adjust it according to your folder structure.
         working-directory: ${{ matrix.environment }}
 
     strategy:


### PR DESCRIPTION
The action template is based on the assumption that there are per-environment-folders for the terraform-code. This however is not clarified anywhere and the working-directory setting can conflict with other layouts. Therefore this change adds a hint to the working-directory setting.