### PR TITLE
OPEB-1770 updated sonarqube templates

### DIFF
--- a/workflow-templates/sonarqube-pr.yml
+++ b/workflow-templates/sonarqube-pr.yml
@@ -74,12 +74,15 @@ jobs:
             
       - name: Setup sonarqube
         uses: warchant/setup-sonar-scanner@v3
+        with:
+          version: '4.6.2.2472'
 
     #   - name: Generate coverprofile
     #     run: |
     #         generate coverage report here
 
       - name: Run an analysis of the PR
+        if: github.actor != 'dependabot[bot]'
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: sonar-scanner

--- a/workflow-templates/sonarqube.yml
+++ b/workflow-templates/sonarqube.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Setup sonarqube
         uses: warchant/setup-sonar-scanner@v3
+        with:
+          version: '4.6.2.2472'
 
     #   - name: Generate coverprofile
     #     run: |


### PR DESCRIPTION
warchant/setup-sonar-scanner@v3 by default is using scanner version 4.2.0.1873 which is quite outdated. This pull request sets the version to currently newest one: 4.6.2.2472

I also added filter for dependabot[bot] user for pull requests decoration so there is no unnecessary load created for analysing pull requests created by dependabot. 