### PR TITLE
Add re-encryption workflow as a template

### DIFF
--- a/workflow-templates/re-encrypt-sops-secrets.properties.json
+++ b/workflow-templates/re-encrypt-sops-secrets.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "Metro Digital: Re-encrypt SOPS secrets",
+  "description": "Re-encrypts the SOPS secrets to provide/remove access to the GitHub users",
+  "iconName": "METRONOM-logo"
+}

--- a/workflow-templates/re-encrypt-sops-secrets.yaml
+++ b/workflow-templates/re-encrypt-sops-secrets.yaml
@@ -1,0 +1,72 @@
+name: Re-encrypt secrets
+on:
+  workflow_dispatch:
+    inputs:
+      token:
+        description: "Personal access token(scope: read:org, repo)"
+        required: true
+jobs:
+  re-encrypt-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail workflow if private key is empty
+        if: env.secret == ''
+        run: |
+          echo "::error::Unable to re-encrypt the secrets, the repository private GPG key is empty."
+          echo "::error::The repository private GPG key is created upon subscription to secret-management and stored as a repository secret."
+          exit 1
+        env:
+          secret: ${{ secrets.GPG_KEY }}
+      - name: Get users with write access on the repository
+        uses: metro-digital-inner-source/get-users-with-access-on-repo@v1.x
+        id: users
+        with:
+          owner: ${{github.event.repository.owner.login}}
+          repo: ${{github.event.repository.name}}
+          access_level: write
+        env:
+          GITHUB_TOKEN: ${{ github.event.inputs.token }}
+      - uses: actions/checkout@v2
+        with:
+          path: actions/generator/workspace
+      - name: Add repository public key
+        working-directory: actions/generator/workspace
+        id: public_keys
+        run: |
+          GPG_KEYS=$(echo '${{ steps.users.outputs.data }}' | jq -rc '.users[].gpg_keys_base64[]')
+          repo_public_key=$(cat .github/.gpg | base64 | tr -d '\n')
+          GPG_KEYS+=( "$repo_public_key" )
+          public_gpg_keys=$(printf '%s\n' "${GPG_KEYS[@]}" | jq -R . | jq -s . | jq -rc .)
+          echo "::set-output name=base64_encoded::$public_gpg_keys"
+      - name: create a local branch on the repository
+        id: branch
+        working-directory: actions/generator/workspace
+        run: |
+          branch="secret-management/sops/reencryption-${{ github.run_id }}"
+          git checkout -b "$branch"
+          echo "::set-output name=work_branch::$branch"
+      - name: Populate public keys file
+        run: |
+          echo '${{ steps.public_keys.outputs.base64_encoded }}' | jq -rc .[] > actions/generator/public_keys.txt
+      - name: Rencrypt-secrets
+        uses: metro-digital-inner-source/sops-encryption-generator@v1.x
+        with:
+          params: '{ "private_key": "${{ secrets.GPG_KEY }}" }'
+      - name: commit and push
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "Re-encrypt secret files to provide access"
+          new_branch: ${{ steps.branch.outputs.work_branch }}
+          cwd: actions/generator/workspace
+      - name: create a pull request on target repository
+        id: pull-request
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/:repo/pulls
+          repo: ${{github.event.repository.full_name}}
+          title: "Re-encryption of secret files"
+          head: ${{ steps.branch.outputs.work_branch }}
+          base: ${{ github.event.repository.default_branch }}
+          body: "The secret files present in the repository are re-encrypted with the GPG keys configured on the GitHub user accounts that has at least PUSH access on this repository."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
One of the features that the secret-management offers is creating a pull request after the re-encryption of secrets, where the secrets are re-encrypted by giving/removing access to the users.

The re-encryption of secrets use to happens automatically based on the GitHub events that gives/removes at least PUSH access on a repository for a GitHub user. Which means there can be multiple pull requests created based on the number of the events triggered. For example, for adding two members  with PUSH access to a repository, gives two pull requests to merge. Also the re-encryption process is not transparent to the users that whenever it fails the users are unaware of the reasons for failure.

Hence, a workflow is created that can re-encrypt the secrets of a repository and create a pull request.
This workflow,
- gives the user ability to trigger the re-encryption whenever required irrespective of the events
- makes the process of re-encryption transparent to the users
- reduces the number of pull requests