### PR TITLE
Replace deprecated workflow commands

### DIFF
--- a/workflow-templates/jenkins-webhook.yml
+++ b/workflow-templates/jenkins-webhook.yml
@@ -39,7 +39,7 @@ jobs:
       id: jenkins_url
       if: contains(env.JENKINS_URL, 'jenkins.example.com')
       run: |
-        echo "::set-output name=status::invalid"
+        echo "status=invalid" >> $GITHUB_OUTPUT
     - name: create issue for missing Jenkins URL
       if: contains(steps.jenkins_url.outputs.status, 'invalid')
       uses: octokit/request-action@v2.x
@@ -70,7 +70,7 @@ jobs:
       id: jenkins_job
       if: contains(env.JENKINS_JOB, 'example-job')
       run: |
-        echo "::set-output name=status::invalid"
+        echo "status=invalid" >> $GITHUB_OUTPUT
     - name: create issue for missing Jenkins URL
       if: contains(steps.jenkins_job.outputs.status, 'invalid')
       uses: octokit/request-action@v2.x
@@ -102,7 +102,7 @@ jobs:
       id: jenkins
       if: env.auth_token == ''
       run: |
-        echo "::set-output name=auth_token::invalid"
+        echo "auth_token=invalid" >> $GITHUB_OUTPUT
       env:
         auth_token: ${{ secrets.JENKINS_AUTH_TOKEN }}
     - name: create issue for missing Jenkins auth token

--- a/workflow-templates/maven-publish.yml
+++ b/workflow-templates/maven-publish.yml
@@ -43,7 +43,7 @@ jobs:
       id: smtpserver
       if: contains(env.SMTP_SERVER_ADDRESS, 'example')
       run: |
-        echo "::set-output name=status::invalid"
+        echo "status=invalid" >> $GITHUB_OUTPUT
     - name: create issue for missing smtp server address
       if: contains(steps.smtpserver.outputs.status, 'invalid')
       uses: octokit/request-action@v2.x
@@ -75,7 +75,7 @@ jobs:
       id: artifactstore
       if: env.username == '' || env.password == ''
       run: |
-        echo "::set-output name=credentials::invalid"
+        echo "credentials=invalid" >> $GITHUB_OUTPUT
       env:
         username: '${{ secrets.ARTIFACT_STORE_CLIENT_USERNAME }}'
         password: '${{ secrets.ARTIFACT_STORE_CLIENT_PASSWORD }}'
@@ -120,7 +120,7 @@ jobs:
         labels: '[ "bug" ]'
         body: |
           The repository ${{ github.repository }} is configured to use maven,
-          but the `mvn-settings.xml` file is missing. This file is needed to 
+          but the `mvn-settings.xml` file is missing. This file is needed to
           authenticate with the artifact store (e.g. artifactory or nexus).
 
           Please create a `mvn-settings.xml` file which contains (and don't contain secrets)
@@ -135,7 +135,7 @@ jobs:
 
           ```
 
-          Please be aware, that the `<id>`s have to match the ones you use 
+          Please be aware, that the `<id>`s have to match the ones you use
           in `pom.xml` in the section `<distributionManagement>`.
 
           You can take an [example from here](https://github.com/metro-digital-inner-source/.github/blob/master/documentation/wf-maven-publish/mvn-settings.xml)
@@ -147,9 +147,9 @@ jobs:
         [ -s "./mvn-settings.xml" ] && {
           secrets=$(cat mvn-settings.xml | grep '<password>' | grep -v -e '<password>${.*}</password>')
           if [ -z "$secrets"]; then
-            echo "::set-output name=contains::false"
+            echo "contains=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=contains::true"
+            echo "contains=true" >> $GITHUB_OUTPUT
           fi
         } || :
     - name: create issue if mvn-settings contains secrets
@@ -161,8 +161,8 @@ jobs:
         title: File mvn-setting.xml contains secrets
         labels: '[ "bug" ]'
         body: |
-          The file `mvn-settings.xml` contains username or passwords. 
-          These should be stored as GitHub secrets of the repository. 
+          The file `mvn-settings.xml` contains username or passwords.
+          These should be stored as GitHub secrets of the repository.
 
           Please [create the respository secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository),
           `ARTIFACT_STORE_CLIENT_USERNAME` and `ARTIFACT_STORE_CLIENT_PASSWORD` with a valid
@@ -182,7 +182,7 @@ jobs:
 
           ```
 
-          Please be aware, that the `<id>`s have to match the ones you use 
+          Please be aware, that the `<id>`s have to match the ones you use
           in `pom.xml` in the section `<distributionManagement>`.
 
           You can take an [example from here](https://github.com/metro-digital-inner-source/.github/blob/master/documentation/wf-maven-publish/mvn-settings.xml)
@@ -192,16 +192,16 @@ jobs:
       id: consolidate-mvn-checks
       run: |
         if [ "${{steps.mvn-settings-exists.outputs.files_exists}}" == "false" ] || [ "${{steps.check-for-secrets.outputs.contains}}" == "true" ]; then
-          echo "::set-output name=status::invalid"
+          echo "status=invalid" >> $GITHUB_OUTPUT
         fi
   finalize-check:
     runs-on: ubuntu-latest
     needs: [check-for-smtp-address, check-for-artifactstore-credentials, check-mvn-settings]
     steps:
     - name: exit workflow
-      if: > 
-        needs.check-for-smtp-address.outputs.status == 'invalid' 
-          || needs.check-for-artifactstore-credentials.outputs.credentials == 'invalid' 
+      if: >
+        needs.check-for-smtp-address.outputs.status == 'invalid'
+          || needs.check-for-artifactstore-credentials.outputs.credentials == 'invalid'
           || needs.check-mvn-settings.outputs.status == 'invalid'
       run: |
         echo "::error::Please resolve the issues labeled as bug for ${{ github.repository }}"
@@ -251,7 +251,7 @@ jobs:
       run: |
         [ -s "./.teamschannel" ] && {
           teams_channel=$(cat .teamschannel)
-          echo "::set-output name=webhook-url::$teams_channel"
+          echo "webhook-url=$teams_channel" >> $GITHUB_OUTPUT
         } || :
     - name: Send message to ms teams
       if: steps.teamschannel.outputs.webhook-url != ''
@@ -272,7 +272,7 @@ jobs:
             watchers="${email},${watchers}"
           done <<< $(cat .watchers)
           watchers=${watchers%?}
-          echo "::set-output name=email-ids::$watchers"
+          echo "email-ids=$watchers" >> $GITHUB_OUTPUT
         } || :
     - name: Send a notification mail
       if: steps.watchers.outputs.email-ids != ''

--- a/workflow-templates/re-encrypt-sops-secrets.yaml
+++ b/workflow-templates/re-encrypt-sops-secrets.yaml
@@ -37,14 +37,14 @@ jobs:
           repo_public_key=$(cat .github/.gpg | base64 | tr -d '\n')
           GPG_KEYS+=( "$repo_public_key" )
           public_gpg_keys=$(printf '%s\n' "${GPG_KEYS[@]}" | jq -R . | jq -s . | jq -rc .)
-          echo "::set-output name=base64_encoded::$public_gpg_keys"
+          echo "base64_encoded=$public_gpg_keys" >> $GITHUB_OUTPUT
       - name: create a local branch on the repository
         id: branch
         working-directory: actions/generator/workspace
         run: |
           branch="secret-management/sops/reencryption-${{ github.run_id }}"
           git checkout -b "$branch"
-          echo "::set-output name=work_branch::$branch"
+          echo "work_branch=$work_branch" >> $GITHUB_OUTPUT
       - name: Populate public keys file
         run: |
           echo '${{ steps.public_keys.outputs.base64_encoded }}' | jq -rc .[] > actions/generator/public_keys.txt

--- a/workflow-templates/re-encrypt-sops-secrets.yaml
+++ b/workflow-templates/re-encrypt-sops-secrets.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           branch="secret-management/sops/reencryption-${{ github.run_id }}"
           git checkout -b "$branch"
-          echo "work_branch=$work_branch" >> $GITHUB_OUTPUT
+          echo "work_branch=$branch" >> $GITHUB_OUTPUT
       - name: Populate public keys file
         run: |
           echo '${{ steps.public_keys.outputs.base64_encoded }}' | jq -rc .[] > actions/generator/public_keys.txt


### PR DESCRIPTION
The set-output and save-state workflow commands are deprecated by GitHub. Hence, replacing them with the new workflow commands.